### PR TITLE
[style] 커스텀 back-to-top 플러그인 추가

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -201,17 +201,17 @@ module.exports = {
       },
     },
   },
-  plugins: {
-    '@vuepress/pwa': {
+  plugins: [
+    ['@vuepress/pwa', {
       serviceWorker: true,
       updatePopup: {
         message: '새 컨텐츠가 등록되었습니다. 새로고침 버튼을 눌러주세요 😄',
         buttonText: '새로고침',
       },
-    },
-    '@vuepress/google-analytics': {
+    }],
+    ['@vuepress/google-analytics', {
       ga: 'UA-87965695-1',
-    },
-    '@vuepress/back-to-top': true,
-  },
+    }],
+    [require('./plugins/custom-back-to-top/')]
+  ],
 };

--- a/docs/.vuepress/plugins/custom-back-to-top/BackToTop.vue
+++ b/docs/.vuepress/plugins/custom-back-to-top/BackToTop.vue
@@ -1,0 +1,34 @@
+
+<script>
+import BackToTop from '@vuepress/plugin-back-to-top/BackToTop'
+export default BackToTop
+
+</script>
+
+<style lang="stylus" scoped>
+$green-100 = #eef6ef
+$green-400 = #3eaf7c
+$green-600 = #388341
+
+// back-to-top 스타일
+.go-to-top
+  z-index: 1
+  cursor: pointer
+  position: fixed
+  bottom: 2rem
+  right: 2.5rem
+  width: 2rem
+  height: 2rem
+  padding: 1rem
+  border-radius: 15px
+  color: $green-400
+  background-color: $green-100
+  @media (max-width: 959px)
+    display: block
+    width: 1.25rem
+    height: 1rem
+    right: 0
+    bottom: 7rem
+    border-top-right-radius: 0
+    border-bottom-right-radius: 0
+</style>

--- a/docs/.vuepress/plugins/custom-back-to-top/enhanceAppFile.js
+++ b/docs/.vuepress/plugins/custom-back-to-top/enhanceAppFile.js
@@ -1,0 +1,6 @@
+import BackToTop from './BackToTop'
+
+export default ({ Vue }) => {
+  // eslint-disable-next-line vue/match-component-file-name
+  Vue.component('BackToTop', BackToTop)
+}

--- a/docs/.vuepress/plugins/custom-back-to-top/index.js
+++ b/docs/.vuepress/plugins/custom-back-to-top/index.js
@@ -1,0 +1,9 @@
+const { path } = require('@vuepress/shared-utils')
+
+module.exports = {
+    enhanceAppFiles: [
+        path.resolve(__dirname, 'enhanceAppFile.js')
+    ],
+
+    globalUIComponents: 'BackToTop'
+}

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -1,20 +1,20 @@
-$green-100 = #eef6ef
-$green-400 = #3eaf7c
-$green-600 = #388341
+// $green-100 = #eef6ef
+// $green-400 = #3eaf7c
+// $green-600 = #388341
 
-// back-to-top 스타일
-svg.go-to-top
-  width: 2rem
-  height: 2rem
-  padding: 1rem
-  border-radius: 15px
-  color: $green-400
-  background-color: $green-100
-  @media (max-width: 959px)
-    display: block !important
-    width: 1.25rem !important
-    height: 1rem
-    right: 0 !important
-    bottom: 7rem !important
-    border-top-right-radius: 0
-    border-bottom-right-radius: 0
+// // back-to-top 스타일
+// svg.go-to-top
+//   width: 2rem
+//   height: 2rem
+//   padding: 1rem
+//   border-radius: 15px
+//   color: $green-400
+//   background-color: $green-100
+//   @media (max-width: 959px)
+//     display: block !important
+//     width: 1.25rem !important
+//     height: 1rem
+//     right: 0 !important
+//     bottom: 7rem !important
+//     border-top-right-radius: 0
+//     border-bottom-right-radius: 0


### PR DESCRIPTION
## 관련 이슈

[https://github.com/joshua1988/vue-camp/issues/75](https://github.com/joshua1988/vue-camp/issues/75)

## 요약
[https://github.com/joshua1988/vue-camp/pull/77#discussion_r698120066](https://github.com/joshua1988/vue-camp/pull/77#discussion_r698120066)

* back-top-plugin 을 커스텀 컴포넌트로 작성 
* style/index.styl 의 스타일 주석 
* config.js 플러그인 설정을 객체 스타일에서 바벨 스타일로 수정 

해당 pr 이 merge 된 다음 develop 브랜치가 최신 master 브랜치보다 뒤에 있어서 master 업데이트 받고 
config.js 에 새로 추가된 plugin 설정도 바벨 스타일로 모두 수정 되어야 할 것 같습니다.
## 리뷰어
@shinyuna 
